### PR TITLE
use already existing socket as tunnel proxy

### DIFF
--- a/src/client/http/connect/connector.rs
+++ b/src/client/http/connect/connector.rs
@@ -222,6 +222,28 @@ impl Connector {
             tls_builder: TlsConnector::builder(),
         }
     }
+
+    #[allow(unused)]
+    pub(crate) fn builder_with_socket(
+        proxies: Arc<Vec<ProxyMatcher>>,
+        resolver: DynResolver,
+        socket: i32,
+    ) -> ConnectorBuilder {
+        ConnectorBuilder {
+            config: Config {
+                proxies,
+                verbose: Verbose::OFF,
+                tcp_nodelay: false,
+                tls_info: false,
+                timeout: None,
+            },
+            #[cfg(feature = "socks")]
+            resolver: resolver.clone(),
+            http: HttpConnector::new_with_resolver_and_socket(resolver, socket),
+            tls_options: TlsOptions::default(),
+            tls_builder: TlsConnector::builder(),
+        }
+    }
 }
 
 impl Service<ConnectRequest> for Connector {

--- a/src/client/http/mod.rs
+++ b/src/client/http/mod.rs
@@ -175,6 +175,7 @@ pub struct Client {
 #[must_use]
 pub struct ClientBuilder {
     config: Config,
+    socket: Option<i32>,
 }
 
 /// The HTTP version preference for the client.
@@ -268,6 +269,7 @@ impl Client {
     #[inline]
     pub fn builder() -> ClientBuilder {
         ClientBuilder {
+            socket: None,
             config: Config {
                 error: None,
                 headers: HeaderMap::new(),
@@ -555,7 +557,10 @@ impl ClientBuilder {
             };
 
             // Build connector
-            let connector = Connector::builder(proxies.clone(), resolver)
+            let connector = match self.socket {
+                Some(socket) => Connector::builder_with_socket(proxies.clone(), resolver, socket),
+                None => Connector::builder(proxies.clone(), resolver)   
+            }
                 .timeout(config.connect_timeout)
                 .tls_info(config.tls_info)
                 .tls_options(tls_options)
@@ -1639,5 +1644,11 @@ impl ClientBuilder {
             .transport_options
             .apply_transport_options(transport_opts);
         self.default_headers(headers).orig_headers(orig_headers)
+    }
+
+    #[allow(missing_docs)]
+    pub fn socket(mut self, socket: i32) -> ClientBuilder {
+        self.socket = Some(socket);
+        self
     }
 }


### PR DESCRIPTION
This PR allows us to use a TcpStream (already existing socket) so that we can tunnel traffic through it