### PR TITLE
pin http2 fork dependency to tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,9 @@ tower = { version = "0.5.2", default-features = false, features = [
 ] }
 bytes = "1.10.1"
 http = "1.3.1"
-http2 = { version = "0.5.8", git = "https://github.com/OpacityLabs/http2", features = ["unstable"] }
+http2 = { version = "0.5.8", git = "https://github.com/OpacityLabs/http2", tag = "0.5.8", features = [
+    "unstable",
+] }
 httparse = "1.10.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"


### PR DESCRIPTION
Okay so, when we have in cargo.toml just a simple crate and it gets pulled from `crates.io`, that is fine and it will get the correct version. When we point to a git repository, >> Cargo assumes that we intend to use the latest commit on the default branch branch << (by default). We can combine the `git` key with `rev`, `tag`, or `branch` and so I've decided to combine it with `tag` going forward. This is so if we update the main/master branch with new commits for every repo that depends on it to not start failing